### PR TITLE
Avoid writing outside of the allocated memory when serializing a roaring bitmap in portable mode

### DIFF
--- a/src/cpp/roaring-js.c
+++ b/src/cpp/roaring-js.c
@@ -140,7 +140,7 @@ int roaring_bitmap_native_serialize_js(roaring_bitmap_js_t * b) {
     roaring_bitmap_to_uint32_array(&b->b, (uint32_t *)(serialized + 1 + sizeof(uint32_t)));
     serializedsize = bufsize;
   } else {
-    bufsize = portablesize;
+    bufsize = portablesize + 1;
     serialized = (char *)malloc(bufsize);
     if (serialized == NULL) {
       return 504;  // Failed to allocate memory


### PR DESCRIPTION
Hello! We're running `roaring-wasm` inside of [PLV8](https://plv8.github.io/)(!), and we've encountered a problem with `RoaringBitmap32#serializeToUint8Array` running into a `RuntimeError: memory access out of bounds` when used in a setting where a certain amount of bitmaps are serialized.

After some debugging we've tracked the problem down to this line, where it looks like the serialization code is writing out one more byte than what was allocated: https://github.com/SalvatorePreviti/roaring-wasm/blob/d834f0f2edd7690152c6dd6e6fbce6fcb67bdf5a/src/cpp/roaring-js.c#L150

We haven't been able to reproduce the crash outside of PLV8, which is why we're not able to make a regression test, sorry 😇 

To validate the change we looked at `roaring-node`, which also adds 1 here: https://github.com/SalvatorePreviti/roaring-node/blob/5053e9218af438b6606b556faafe26f3210ecab5/src/cpp/RoaringBitmap32.cpp#L746