### PR TITLE
Enable SIMD

### DIFF
--- a/scripts/compile-wasm.js
+++ b/scripts/compile-wasm.js
@@ -82,6 +82,10 @@ async function compileWasm() {
   emccFlags.push("-Isubmodules/CRoaring/include");
   emccFlags.push("-O3");
   emccFlags.push("-g0");
+  emccFlags.push("-msimd128");
+  emccFlags.push("-mavx");
+  emccFlags.push("-msse4.1");
+  emccFlags.push("-msse3");
 
   const cflags = [];
   cflags.push("-O3");


### PR DESCRIPTION
This PR enables compilation with SIMD WASM instructions. I decided on the `emcc` flags by comparing the intrinsic headers [used by CRoaring](https://github.com/RoaringBitmap/CRoaring/blob/master/include/roaring/portability.h#L127-L134) with the flags from the [emscripten simd documentation](https://emscripten.org/docs/porting/simd.html).

Compiling with SIMD enabled means the generated WASM can only run on targets with SIMD support though. According to [webassembly.org](https://webassembly.org/roadmap/), SIMD is supported is recent modern browsers and since Node v16.4 (see below). Alternatively we need to create two WASM artifacts (with/without SIMD) and [select at runtime](https://v8.dev/features/simd#enabling-simd-support) -- that would create more overhead both in build size and code complexity though.

<img width="1077" alt="Roadmap_-_WebAssembly" src="https://github.com/SalvatorePreviti/roaring-wasm/assets/2518/07f00632-1f41-4aff-b22d-ae2c7643a7c4">

To verify the performance impact, the benchmark test could benefit from being improved. I didn't include that for now though.